### PR TITLE
Load API key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Install python3
 Install pip: 'sudo easy_install pip3' in Terminal
 Install nose: 'sudo pip3 install nose' or 'sudo easy_install nose'
 Install requests library: 'sudo pip3 install requests'
+Set the OpenWeather API key using an environment variable:
+    export WEATHER_API_KEY=<your_api_key>
 Following Test Suite is available: weather_api_test.py
 
 Project Files Definition:

--- a/base_test.py
+++ b/base_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
+import os
 import unittest
 from http_requests import SampleHTTPRequests
 
@@ -8,7 +9,12 @@ class BaseTest(unittest.TestCase):
     """@description: class to provide SetUp and TearDown as well as global vars
                @author: usharifzoda"""
 
-    API_KEY = "002c3ceedee6bd9c6f5abbb7b476b0da"
+    API_KEY = os.environ.get("WEATHER_API_KEY")
+
+    if not API_KEY:
+        raise EnvironmentError(
+            "WEATHER_API_KEY environment variable is not set"
+        )
 
     def setUp(self):
         self.api_requests = SampleHTTPRequests()


### PR DESCRIPTION
## Summary
- fetch `WEATHER_API_KEY` from the environment instead of hardcoding it
- document how to set `WEATHER_API_KEY` in README

## Testing
- `printf "New York\n10007\n40.7128\n-74.0060\n" | nosetests -v -s --nologcapture weather_api_test.py` *(fails: `collections` has no attribute `Callable`)*

------
https://chatgpt.com/codex/tasks/task_e_687806ab2f9c8325931b77de8278e576